### PR TITLE
Using VG map instead of VG mpmap in sibling mapping workflow

### DIFF
--- a/scripts/setup_sibling_mapping_script.part_4.sh
+++ b/scripts/setup_sibling_mapping_script.part_4.sh
@@ -112,6 +112,7 @@ if [ $RUN_SMALL_TEST == false ]; then
         REF_INDEX_FILE='${WORKFLOW_INPUT_DIR}/hs37d5.fa.fai' \
         REF_DICT_FILE='${WORKFLOW_INPUT_DIR}/hs37d5.dict' \
         VG_CONTAINER='quay.io/vgteam/vg:v1.19.0' \
+        VGMPMAP_MODE='false' \
         SPLIT_READ_CORES=16 \
         SPLIT_READ_DISK=50 \
         MAP_CORES=32 \


### PR DESCRIPTION
Using VG map instead of VG mpmap in sibling mapping workflow due to memory leak issue with mpmap.