### PR TITLE
Allow testing Giraffe in small memory

### DIFF
--- a/workflows/giraffe.wdl
+++ b/workflows/giraffe.wdl
@@ -234,7 +234,8 @@ workflow Giraffe {
         in_merged_bam_file=mergeAlignmentBAMChunks.merged_bam_file,
         in_merged_bam_file_index=mergeAlignmentBAMChunks.merged_bam_file_index,
         in_path_list_file=pipeline_path_list_file,
-        in_prefix_to_strip=REFERENCE_PREFIX
+        in_prefix_to_strip=REFERENCE_PREFIX,
+        mem_gb=if MAP_MEM < 20 then MAP_MEM else 20
     }
 
     ##

--- a/workflows/giraffe_and_deepvariant.wdl
+++ b/workflows/giraffe_and_deepvariant.wdl
@@ -261,7 +261,8 @@ workflow GiraffeDeepVariant {
         in_merged_bam_file=mergeAlignmentBAMChunks.merged_bam_file,
         in_merged_bam_file_index=mergeAlignmentBAMChunks.merged_bam_file_index,
         in_path_list_file=pipeline_path_list_file,
-        in_prefix_to_strip=REFERENCE_PREFIX
+        in_prefix_to_strip=REFERENCE_PREFIX,
+        mem_gb=if MAP_MEM < 20 then MAP_MEM else 20
     }
 
     ##

--- a/workflows/giraffe_and_deepvariant_fromGAF.wdl
+++ b/workflows/giraffe_and_deepvariant_fromGAF.wdl
@@ -139,7 +139,8 @@ workflow GiraffeDeepVariantFromGAF {
         in_merged_bam_file=sortBAM.sorted_bam,
         in_merged_bam_file_index=sortBAM.sorted_bam_index,
         in_path_list_file=pipeline_path_list_file,
-        in_prefix_to_strip=REFERENCE_PREFIX
+        in_prefix_to_strip=REFERENCE_PREFIX,
+        mem_gb=if VG_MEM < 20 then VG_MEM else 20
     }
 
     ##

--- a/workflows/vg_indel_realign.wdl
+++ b/workflows/vg_indel_realign.wdl
@@ -41,7 +41,8 @@ workflow vgMultiMapCall {
             in_sample_name=SAMPLE_NAME,
             in_merged_bam_file=INPUT_BAM_FILE,
             in_merged_bam_file_index=INPUT_BAM_FILE_INDEX,
-            in_path_list_file=pipeline_path_list_file
+            in_path_list_file=pipeline_path_list_file,
+            mem_gb=if MAP_MEM < 20 then MAP_MEM else 20
     }
     # Run distributed Indel Realignment on contig BAMs
     scatter (gatk_caller_input_files in splitBAMbyPath.bams_and_indexes_by_contig) {


### PR DESCRIPTION
This lets us limit the bam splitting memory so that hopefully I can run `giraffe.wdl` through on my laptop.