### PR TITLE
Use newer containers for giraffe.wdl

### DIFF
--- a/tasks/bioinfo_utils.wdl
+++ b/tasks/bioinfo_utils.wdl
@@ -52,7 +52,7 @@ task indexVcf {
         cpu: 1
         memory: in_index_mem + " GB"
         disks: "local-disk " + in_index_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 
@@ -78,7 +78,7 @@ task fixVCFContigNaming {
         preemptible: 2
         memory: in_index_mem + " GB"
         disks: "local-disk " + in_index_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 
@@ -101,7 +101,7 @@ task removeHomRefs {
         preemptible: 2
         memory: in_index_mem + " GB"
         disks: "local-disk " + in_index_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 
@@ -175,7 +175,7 @@ task concatClippedVCFChunks {
         memory: mem_gb + " GB"
         cpu: 1
         disks: "local-disk " + disk_size + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 

--- a/workflows/giraffe_and_deeptrio.mapper.wdl
+++ b/workflows/giraffe_and_deeptrio.mapper.wdl
@@ -1042,7 +1042,7 @@ task concatClippedVCFChunks {
         time: 60
         memory: in_call_mem + " GB"
         disks: "local-disk " + in_call_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 

--- a/workflows/giraffe_and_deeptrio.wdl
+++ b/workflows/giraffe_and_deeptrio.wdl
@@ -1291,7 +1291,7 @@ task concatClippedVCFChunks {
         time: 60
         memory: in_call_mem + " GB"
         disks: "local-disk " + in_call_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 

--- a/workflows/vg_deeptrio_calling_workflow.wdl
+++ b/workflows/vg_deeptrio_calling_workflow.wdl
@@ -869,7 +869,7 @@ task concatClippedVCFChunks {
         time: 60
         memory: in_mem + " GB"
         disks: "local-disk " + in_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 

--- a/workflows/vg_multi_map_call.wdl
+++ b/workflows/vg_multi_map_call.wdl
@@ -1429,7 +1429,7 @@ task runVCFClipper {
     runtime {
         memory: in_vgcall_mem + " GB"
         disks: "local-disk " + in_vgcall_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 
@@ -1465,7 +1465,7 @@ task concatClippedVCFChunks {
         time: 60
         memory: in_vgcall_mem + " GB"
         disks: "local-disk " + in_vgcall_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 
@@ -1537,7 +1537,7 @@ task normalizeVCF {
         cpu: in_vgcall_cores
         memory: in_vgcall_mem + " GB"
         disks: "local-disk " + in_vgcall_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 

--- a/workflows/vg_trio_giraffe_deeptrio_workflow.wdl
+++ b/workflows/vg_trio_giraffe_deeptrio_workflow.wdl
@@ -531,7 +531,7 @@ task runSplitJointGenotypedVCF {
         cpu: in_cores
         memory: in_mem + " GB"
         disks: "local-disk " + in_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 
@@ -782,7 +782,7 @@ task concatClippedVCFChunks {
         time: 60
         memory: in_vgcall_mem + " GB"
         disks: "local-disk " + in_vgcall_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 
@@ -860,7 +860,7 @@ task normalizeVCF {
         cpu: in_vgcall_cores
         memory: in_vgcall_mem + " GB"
         disks: "local-disk " + in_vgcall_disk + " SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 

--- a/workflows/vg_trio_multi_map_call.wdl
+++ b/workflows/vg_trio_multi_map_call.wdl
@@ -610,7 +610,7 @@ task runSplitJointGenotypedVCF {
     runtime {
         memory: 50 + " GB"
         disks: "local-disk 100 SSD"
-        docker: "quay.io/biocontainers/bcftools@sha256:95c212df20552fc74670d8f16d20099d9e76245eda6a1a6cfff4bd39e57be01b"
+        docker: "quay.io/biocontainers/bcftools:1.20--h8b25389_0"
     }
 }
 


### PR DESCRIPTION
Splits up the indexReference task into two so that each part can depend on a singular up to date container, and so no one needs to maintain a container including both tools in one.

Also cherry picks https://github.com/vgteam/vg_wdl/commit/27d304fc4df82e06d077fce0b76b048d96ce5469 which updates the bcftools container