### PR TITLE
Allocate space for O(2 * input size) temp files for KMC

### DIFF
--- a/tasks/bioinfo_utils.wdl
+++ b/tasks/bioinfo_utils.wdl
@@ -674,7 +674,7 @@ task kmerCountingKMC {
         Int kmer_length
         Int max_ram = 64
 	    Int nb_cores = 16
-        Int disk_size = round(size(input_read_file_1, "G") + size(input_read_file_2, "G")) + 10
+        Int disk_size = 3*round(size(input_read_file_1, "G") + size(input_read_file_2, "G")) + 10
     }
 
     command <<<


### PR DESCRIPTION
This should fix https://github.com/vgteam/vg_wdl/issues/158, where it was reported that KMC can need temp files larger than the input file size.