### PR TITLE
fix: change `mem_gb` type from `String` to `Int` in task inputs

### DIFF
--- a/tasks/bioinfo_utils.wdl
+++ b/tasks/bioinfo_utils.wdl
@@ -235,7 +235,7 @@ task sortBAM {
         String in_prefix_to_strip = ""
         Int nb_cores = 16
         Int disk_size = 5 * round(size(in_bam_file, "G")) + 20
-        String mem_gb = 16
+        Int mem_gb = 16
     }
 
     String out_prefix = basename(in_bam_file, ".bam")

--- a/tasks/gam_gaf_utils.wdl
+++ b/tasks/gam_gaf_utils.wdl
@@ -181,7 +181,7 @@ task surjectGAFtoSortedBAM {
         Boolean make_bam_index = false
         Boolean input_is_gam = false
         Int nb_cores = 16
-        String mem_gb = 120
+        Int mem_gb = 120
         Int disk_size = 5 * round(size(in_gbz_file, 'G') + size(in_gaf_file, 'G')) + 50
         String vg_docker = "quay.io/vgteam/vg:v1.64.0"
     }
@@ -249,7 +249,7 @@ task surjectGAFtoBAM {
         Int in_max_fragment_length = 3000
         Boolean input_is_gam = false
         Int nb_cores = 16
-        String mem_gb = 120
+        Int mem_gb = 120
         Int disk_size = 5 * round(size(in_gbz_file, 'G') + size(in_gaf_file, 'G')) + 50
         String vg_docker = "quay.io/vgteam/vg:v1.64.0"
     }

--- a/tasks/vg_map_hts.wdl
+++ b/tasks/vg_map_hts.wdl
@@ -42,7 +42,7 @@ task runVGGIRAFFE {
         String in_giraffe_options
         String in_sample_name
         Int nb_cores = 16
-        String mem_gb = 120
+        Int mem_gb = 120
         Int disk_size = 3 * round(size(fastq_file_1, 'G') + size(fastq_file_2, 'G') + size(in_gbz_file, 'G') + size(in_dist_file, 'G') + size(in_min_file, 'G') + size(in_zipcodes_file, 'G')) + 50
         String vg_docker = "quay.io/vgteam/vg:v1.64.0"
     }


### PR DESCRIPTION
Four tasks—`sortBAM`, `surjectGAFtoSortedBAM`, `surjectGAFtoBAM`, and `runVGGIRAFFE`—declare `String mem_gb` with integer default values (e.g., `String mem_gb = 120`). Since `120` is an `Int`, not a `String`, sprocket reports type mismatch errors at each declaration site and at every workflow call site that passes an `Int` to these parameters.

Changing the type to `Int mem_gb` fixes ~20 sprocket diagnostics across three task files and the workflows that call them. The runtime blocks use `mem_gb + " GB"`, which works identically with `Int` since WDL coerces `Int` to `String` in concatenation.

Relates to #6.