### PR TITLE
fix: double-escape regex metacharacters in `decoy_regex` strings

### DIFF
--- a/workflows/vg_construct_and_index.wdl
+++ b/workflows/vg_construct_and_index.wdl
@@ -38,7 +38,7 @@ workflow vg_construct_and_index {
         Boolean in_small_resources = false
          
         # regex to use in grep for extracting decoy contig names from reference FASTA
-        String decoy_regex = ">GL\|>NC_007605\|>hs37d5\|>hs38d1_decoys\|>chrEBV\|>chrUn\|>chr\([1-2][1-9]\|[1-9]\|Y\)_"
+        String decoy_regex = ">GL\\|>NC_007605\\|>hs37d5\\|>hs38d1_decoys\\|>chrEBV\\|>chrUn\\|>chr\\([1-2][1-9]\\|[1-9]\\|Y\\)_"
         
         # vg docker image tag
         String vg_docker = "quay.io/vgteam/vg:v1.64.0"

--- a/workflows/vg_trio_giraffe_deeptrio_workflow.wdl
+++ b/workflows/vg_trio_giraffe_deeptrio_workflow.wdl
@@ -56,7 +56,7 @@ workflow vgTrioPipeline {
         Boolean SNPEFF_ANNOTATION = false               # Set to 'true' to run snpEff annotation on the joint genotyped VCF.
         Boolean CLEANUP_FILES = false                   # Set to 'true' to turn on intermediate file cleanup.
         Boolean ABRA_REALIGN = true                     # Set to 'true' to use ABRA2 IndelRealigner instead of GATK for indel realignmen
-        String DECOY_REGEX = ">GL\|>NC_007605\|>hs37d5\|>hs38d1_decoys\|>chrEBV\|>chrUn\|>chr\([1-2][1-9]\|[1-9]\|Y\)_" # grep regular expression string that is used to extract decoy contig ids. USE_DECOYS must be set to 'true'
+        String DECOY_REGEX = ">GL\\|>NC_007605\\|>hs37d5\\|>hs38d1_decoys\\|>chrEBV\\|>chrUn\\|>chr\\([1-2][1-9]\\|[1-9]\\|Y\\)_" # grep regular expression string that is used to extract decoy contig ids. USE_DECOYS must be set to 'true'
     }
     
     File PROBAND_INPUT_READ_FILE_1 = SIBLING_INPUT_READ_FILE_1_LIST[0]  # Input proband 1st read pair fastq.gz


### PR DESCRIPTION
The `decoy_regex` strings in `vg_construct_and_index.wdl` and `vg_trio_giraffe_deeptrio_workflow.wdl` use `\|`, `\(`, and `\)` to express grep regex alternation and grouping. These are not valid WDL 1.0 escape sequences—sprocket flags 26 errors across the two files.

The [WDL 1.0 spec](https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md#global-grammar-rules) defines string escape sequences as a closed grammar in the "Global Grammar Rules" section:

> `$string` can accept the following between single or double-quotes:
>
> - Any character not in set: `\\`, `"` (or `'` for single-quoted string), `\n`
> - An escape sequence starting with `\\`, followed by one of the following characters: `\\`, `"`, `'`, `[nrbtfav]`, `?`
> - An escape sequence starting with `\\`, followed by 1 to 3 digits of value 0 through 7 inclusive. This specifies an octal escape code.
> - An escape sequence starting with `\\x`, followed by hexadecimal characters `0-9a-fA-F`. This specifies a hexidecimal escape code.
> - An escape sequence starting with `\\u` or `\\U` followed by either 4 or 8 hexadecimal characters `0-9a-fA-F`. This specifies a unicode code point.

The characters ` |`, `(`, and `)` do not appear in the valid set, nor do they match any other escape form. There is no fallback for unrecognized sequences—`\|` is a lexer error per spec, not a pass-through. Engines that silently accept it (e.g., Cromwell) are being lenient beyond what the spec permits.

Doubling the backslashes (`\\|`, `\\(`, `\\)`) produces the same literal string that grep expects while satisfying the spec.

Relates to #6.