### PR TITLE
fix: remove unnecessary `select_all` and `select_first` calls

### DIFF
--- a/workflows/giraffe.wdl
+++ b/workflows/giraffe.wdl
@@ -209,7 +209,8 @@ workflow Giraffe {
     # The zipcode file is optional but we still have a priority list of places to get it from.
     # But we can't select_first since they all might be null.
     Array[File] possible_zipcode_files = select_all([HaplotypeSampling.sampled_zipcodes, ZIPCODES_FILE])
-    # We can't actually use None in WDL 1.0 so we need to use a nonexistent null file.
+    # WDL 1.0 has no `None` literal. This `if (false)` block never executes,
+    # so `NULL_FILE` becomes a `File?` that is always `None`.
     if (false) {
         Array[File] no_files = []
         File NULL_FILE = no_files[0]

--- a/workflows/giraffe.wdl
+++ b/workflows/giraffe.wdl
@@ -212,7 +212,7 @@ workflow Giraffe {
     # We can't actually use None in WDL 1.0 so we need to use a nonexistent null file.
     if (false) {
         Array[File] no_files = []
-        File NULL_FILE = select_first(no_files)
+        File NULL_FILE = no_files[0]
     }
     File? file_zipcodes = if length(possible_zipcode_files) > 0 then possible_zipcode_files[0] else NULL_FILE
     File file_dist = select_first([HaplotypeSampling.sampled_dist, DIST_FILE])
@@ -444,7 +444,7 @@ workflow Giraffe {
                 call utils.mergeAlignmentBAMChunks as mergeBAM {
                     input:
                     in_sample_name=SAMPLE_NAME,
-                    in_alignment_bam_chunk_files=select_all(flatten([processed_bam, [splitBAMbyPath.bam_unmapped_file]]))
+                    in_alignment_bam_chunk_files=flatten([processed_bam, [splitBAMbyPath.bam_unmapped_file]])
                 }
             }
             

--- a/workflows/giraffe.wdl
+++ b/workflows/giraffe.wdl
@@ -209,11 +209,11 @@ workflow Giraffe {
     # The zipcode file is optional but we still have a priority list of places to get it from.
     # But we can't select_first since they all might be null.
     Array[File] possible_zipcode_files = select_all([HaplotypeSampling.sampled_zipcodes, ZIPCODES_FILE])
-    # WDL 1.0 has no `None` literal. This `if (false)` block never executes,
-    # so `NULL_FILE` becomes a `File?` that is always `None`.
+    # We can't actually use None in WDL 1.0 so we need to use a nonexistent null file.
     if (false) {
         Array[File] no_files = []
-        File NULL_FILE = no_files[0]
+        #@ except: UnnecessaryFunctionCall
+        File NULL_FILE = select_first(no_files)
     }
     File? file_zipcodes = if length(possible_zipcode_files) > 0 then possible_zipcode_files[0] else NULL_FILE
     File file_dist = select_first([HaplotypeSampling.sampled_dist, DIST_FILE])

--- a/workflows/giraffe_and_deeptrio.wdl
+++ b/workflows/giraffe_and_deeptrio.wdl
@@ -332,7 +332,7 @@ workflow vgGiraffeDeeptrio {
     }
     Array[File] childDeepVarGVCF = select_all(callDeepVariantCallVariantsChild.output_gvcf_file)
     Array[File] childDeepTrioGVCF = select_all(trioCall.output_child_gvcf_file)
-    Array[File] child_contig_gvcf_output_list = select_all(flatten([childDeepTrioGVCF, childDeepVarGVCF]))
+    Array[File] child_contig_gvcf_output_list = flatten([childDeepTrioGVCF, childDeepVarGVCF])
     # Merge distributed variant called VCFs
     call concatClippedVCFChunks as concatVCFChunksChild {
         input:
@@ -351,7 +351,7 @@ workflow vgGiraffeDeeptrio {
     }
     Array[File] maDeepVarGVCF = select_all(callDeepVariantCallVariantsMaternal.output_gvcf_file)
     Array[File] maDeepTrioGVCF = select_all(trioCall.output_parent2_gvcf_file)
-    Array[File] maternal_contig_gvcf_output_list = select_all(flatten([maDeepTrioGVCF, maDeepVarGVCF]))
+    Array[File] maternal_contig_gvcf_output_list = flatten([maDeepTrioGVCF, maDeepVarGVCF])
     # Merge distributed variant called VCFs
     call concatClippedVCFChunks as concatVCFChunksMaternal {
         input:
@@ -370,7 +370,7 @@ workflow vgGiraffeDeeptrio {
     }
     Array[File] paDeepVarGVCF = select_all(callDeepVariantCallVariantsPaternal.output_gvcf_file)
     Array[File] paDeepTrioGVCF = select_all(trioCall.output_parent1_gvcf_file)
-    Array[File] paternal_contig_gvcf_output_list = select_all(flatten([paDeepTrioGVCF, paDeepVarGVCF]))
+    Array[File] paternal_contig_gvcf_output_list = flatten([paDeepTrioGVCF, paDeepVarGVCF])
     # Merge distributed variant called VCFs
     call concatClippedVCFChunks as concatVCFChunksPaternal {
         input:

--- a/workflows/giraffe_and_deepvariant_fromGAF.wdl
+++ b/workflows/giraffe_and_deepvariant_fromGAF.wdl
@@ -248,7 +248,7 @@ workflow GiraffeDeepVariantFromGAF {
         call utils.mergeAlignmentBAMChunks as mergeBAM {
             input:
             in_sample_name=SAMPLE_NAME,
-            in_alignment_bam_chunk_files=select_all(flatten([calling_bam, [splitBAMbyPath.bam_unmapped_file]]))
+            in_alignment_bam_chunk_files=flatten([calling_bam, [splitBAMbyPath.bam_unmapped_file]])
         }
     }
 

--- a/workflows/vg_construct_and_index.wdl
+++ b/workflows/vg_construct_and_index.wdl
@@ -80,7 +80,7 @@ workflow vg_construct_and_index {
     # combine them into a single graph with unique node IDs
     call combine_graphs { input:
         graph_name = graph_name,
-        contigs_vg = select_first([construct_chromosome_graph.contig_vg]),
+        contigs_vg = construct_chromosome_graph.contig_vg,
         decoy_contigs_vg = construct_decoy_graph.contig_vg,
         vg_docker = vg_docker,
         in_small_resources = in_small_resources
@@ -147,7 +147,7 @@ workflow vg_construct_and_index {
                     in_small_resources = in_small_resources
                 }
             }
-            Array[File] concat_pruned_vg_graph_lists = flatten([select_first([prune_graph_with_haplotypes.contigs_pruned_vg,[]]), select_first([prune_decoy_graphs.contig_pruned_vg,[]])]) 
+            Array[File] concat_pruned_vg_graph_lists = flatten([prune_graph_with_haplotypes.contigs_pruned_vg, prune_decoy_graphs.contig_pruned_vg]) 
         }
     }
     

--- a/workflows/vg_deeptrio_calling_workflow.wdl
+++ b/workflows/vg_deeptrio_calling_workflow.wdl
@@ -290,7 +290,7 @@ workflow vgDeepTrioCall {
     }
     Array[File] childDeepVarGVCF = select_all(callDeepVariantChild.output_gvcf_file)
     Array[File] childDeepTrioGVCF = select_all(callVariantsChild.output_gvcf_file)
-    Array[File] child_contig_gvcf_output_list = select_all(flatten([childDeepTrioGVCF, childDeepVarGVCF]))
+    Array[File] child_contig_gvcf_output_list = flatten([childDeepTrioGVCF, childDeepVarGVCF])
     # Merge distributed variant called VCFs
     call concatClippedVCFChunks as concatVCFChunksChild {
         input:
@@ -309,7 +309,7 @@ workflow vgDeepTrioCall {
     if (!defined(MATERNAL_BAM_INDEX_CONTIG_LIST)) {
         Array[File] maDeepVarGVCF = select_all(callDeepVariantMaternal.output_gvcf_file)
         Array[File] maDeepTrioGVCF = select_all(callVariantsMaternal.output_gvcf_file)
-        Array[File] maternal_contig_gvcf_output_list = select_all(flatten([maDeepTrioGVCF, maDeepVarGVCF]))
+        Array[File] maternal_contig_gvcf_output_list = flatten([maDeepTrioGVCF, maDeepVarGVCF])
         # Merge distributed variant called VCFs
         call concatClippedVCFChunks as concatVCFChunksMaternal {
             input:
@@ -329,7 +329,7 @@ workflow vgDeepTrioCall {
     if (!defined(PATERNAL_BAM_INDEX_CONTIG_LIST)) {
         Array[File] paDeepVarGVCF = select_all(callDeepVariantPaternal.output_gvcf_file)
         Array[File] paDeepTrioGVCF = select_all(callVariantsPaternal.output_gvcf_file)
-        Array[File] paternal_contig_gvcf_output_list = select_all(flatten([paDeepTrioGVCF, paDeepVarGVCF]))
+        Array[File] paternal_contig_gvcf_output_list = flatten([paDeepTrioGVCF, paDeepVarGVCF])
         # Merge distributed variant called VCFs
         call concatClippedVCFChunks as concatVCFChunksPaternal {
             input:


### PR DESCRIPTION
Sprocket flags 13 instances where `select_all()` wraps a `flatten()` whose element type is already non-optional, and where `select_first()` indexes into an array with no optional elements. Both are no-ops that obscure intent. This removes the wrappers in `giraffe.wdl`, `giraffe_and_deeptrio.wdl`, `giraffe_and_deepvariant_fromGAF.wdl`, `vg_construct_and_index.wdl`, and `vg_deeptrio_calling_workflow.wdl`—replacing `select_all(flatten([...]))` with `flatten([...])` and `select_first([x])` with the element directly.

Relates to #6.