### PR TITLE
fix: update `generic_tasks.wdl` to valid WDL 1.0 syntax

### DIFF
--- a/tasks/generic_tasks.wdl
+++ b/tasks/generic_tasks.wdl
@@ -1,73 +1,76 @@
 version 1.0
 
 task shard_fastq {
-    File fastq1
-    File fastq2
-    Int diskGB
-    
-    command <<<
-        fastq_splitter.sh ${fastq1} ${fastq2}}
-    >>>
-
-    runtime{
-        cpu: "8"
-        memory : "4 GB"
-        disks : "local-disk " + diskGB + " HDD"
-        docker: "erictdawson/fastq-splitter"
-        preemptible : 3
+    input {
+        File fastq1
+        File fastq2
+        Int diskGB
     }
 
-    output{
+    command <<<
+        fastq_splitter.sh ~{fastq1} ~{fastq2}
+    >>>
+
+    runtime {
+        cpu: 8
+        memory: "4 GB"
+        disks: "local-disk " + diskGB + " HDD"
+        docker: "erictdawson/fastq-splitter"
+        preemptible: 3
+    }
+
+    output {
         Array[File] firstSplits = glob("*_1.fastq.part*")
         Array[File] secondSplits = glob("*_2.fastq.part*")
     }
 }
 
-
 task concat {
-    Array[File] shard_gam
-    String output_name
-    Int diskGB
+    input {
+        Array[File] shard_gam
+        String output_name
+        Int diskGB
+    }
 
     command <<<
-        cat ${sep=" " shard_gam} > "${output_name}.gam"
+        cat ~{sep=" " shard_gam} > "~{output_name}.gam"
     >>>
 
     runtime {
-        docker : "erictdawson/base"
-        cpu : 1
-        memory : "1 GB"
-        disks: "local-disk " + diskGB + "  HDD"
-        preemptible : 4
+        docker: "erictdawson/base"
+        cpu: 1
+        memory: "1 GB"
+        disks: "local-disk " + diskGB + " HDD"
+        preemptible: 4
     }
 
     output {
-        File gam = "${output_name}.gam"
+        File gam = "~{output_name}.gam"
     }
 }
 
-task falseTouchFile{
-    File input
-    Int diskGB
+task falseTouchFile {
+    input {
+        File in_file
+        Int diskGB
+    }
 
     command <<<
-        touch ${input}
+        touch ~{in_file}
     >>>
 
-    runtime{
-        docker : "erictdawson/base"
-        cpu : 1
-        memory : "1 GB"
-        disks : "local-disk " + diskGB + " HDD
-        preemptible : 7
+    runtime {
+        docker: "erictdawson/base"
+        cpu: 1
+        memory: "1 GB"
+        disks: "local-disk " + diskGB + " HDD"
+        preemptible: 7
     }
 
-    output{
-        File output = "${input}
+    output {
+        File output = "~{in_file}"
     }
-
 }
 
-workflow strawman_flow{
-
+workflow strawman_flow {
 }


### PR DESCRIPTION
The `generic_tasks.wdl` file predates WDL 1.0 and fails to parse entirely under sprocket (18 errors). Task inputs lack `input {}` blocks, the `falseTouchFile` task uses `input` as a variable name (a reserved keyword in WDL 1.0), `cpu` is declared as a string instead of an integer, command blocks use `${}` instead of `~{}`, and two string literals are unclosed.

This rewrites the file into valid WDL 1.0: adds `input {}` blocks to all three tasks, renames the reserved `input` variable to `in_file`, fixes `cpu: "8"` to `cpu: 8`, switches command interpolation to `~{}`, and closes the broken strings. The empty `strawman_flow` workflow is preserved as-is.

Relates to #6.